### PR TITLE
fix: correct video source path in welcome.md

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -6,7 +6,7 @@ Today, we'll explore how to use **GitHub Copilot** to become a better coder—no
 > "Copilot is your sous-chef, not your baker." 👩‍🍳
 
 <video width="100%" style="max-width: 800px;" controls autoplay loop muted playsinline>
-  <source src="../assets/20250913-080949-sora" type="video/mp4">
+  <source src="../assets/20250913-080949-sora.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 


### PR DESCRIPTION
This pull request makes a minor fix to the video source path in the `docs/welcome.md` file, ensuring the correct `.mp4` extension is used for the video file.